### PR TITLE
Refactor: Replace Navigator with GoRouter for system routes

### DIFF
--- a/lib/core/extensions/context_extension.dart
+++ b/lib/core/extensions/context_extension.dart
@@ -1,28 +1,6 @@
 import 'package:flutter/material.dart';
 
 extension ContextExtension on BuildContext {
-  void push(Widget screen, {String? routeName}) {
-    Navigator.of(this).push(
-      MaterialPageRoute(
-        settings: RouteSettings(name: routeName),
-        builder: (ctx) => screen,
-      ),
-    );
-  }
-
-  void pushReplacement(Widget screen, {String? routeName}) {
-    Navigator.of(this).pushReplacement(
-      MaterialPageRoute(
-        settings: RouteSettings(name: routeName),
-        builder: (ctx) => screen,
-      ),
-    );
-  }
-
-  void pop<T extends Object?>([T? result]) {
-    Navigator.of(this).pop(result);
-  }
-
   void showFailureSnackBar(String message) {
     ScaffoldMessenger.of(this)
       ..clearSnackBars()

--- a/lib/core/navigation/router.dart
+++ b/lib/core/navigation/router.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:marketinya/core/config/service_locator.dart';
+import 'package:marketinya/core/models/client.dart';
 import 'package:marketinya/core/navigation/auth_notifier.dart';
 import 'package:marketinya/core/navigation/routes.dart';
 import 'package:marketinya/core/navigation/tab_navigation_screen_shell.dart';
 import 'package:marketinya/core/repositories/authentication_repository.dart';
 import 'package:marketinya/system/auth/login/login_screen.dart';
+import 'package:marketinya/system/screens/clients/widgets/client_editor/client_editor_screen.dart';
 import 'package:marketinya/system/screens/system_layout.dart';
 import 'package:marketinya/website/pages/connect_with_us/connect_with_us_screen.dart';
 import 'package:marketinya/website/pages/home/home_screen.dart';
@@ -55,6 +57,46 @@ final GoRouter router = GoRouter(
       path: Routes.systemHome.path,
       pageBuilder: (context, state) =>
           const NoTransitionPage(child: SystemLayout()),
+      routes: [
+        GoRoute(
+          path: 'add',
+          name: 'addClient',
+          pageBuilder: (context, state) {
+            void Function(Client)? onClientUpdated;
+            if (state.extra != null && state.extra is Map<String, dynamic>) {
+              final extra = state.extra! as Map<String, dynamic>;
+              if (extra.containsKey('onClientUpdated')) {
+                onClientUpdated =
+                    extra['onClientUpdated'] as void Function(Client);
+              }
+            }
+
+            return NoTransitionPage(
+              child: ClientEditorScreen(
+                onClientUpdated: onClientUpdated ?? ((_) {}),
+              ),
+            );
+          },
+        ),
+        GoRoute(
+          path: 'edit',
+          name: 'editClient',
+          pageBuilder: (context, state) {
+            final extra = state.extra! as Map<String, dynamic>;
+            final client = extra['client'] as Client;
+            final onClientUpdated =
+                extra['onClientUpdated'] as void Function(Client);
+
+            return NoTransitionPage(
+              child: ClientEditorScreen(
+                client: client,
+                onClientUpdated: onClientUpdated,
+              ),
+            );
+          },
+        ),
+        // Add other system routes here
+      ],
     ),
   ],
 );
@@ -63,30 +105,32 @@ final GoRouter router = GoRouter(
 String? _authGuard(BuildContext context, GoRouterState state) {
   final isLoginRoute = state.uri.path == Routes.login.path;
   final isSystemRoute = state.uri.path.startsWith('/system');
+  final isEditClientRoute = state.uri.path == Routes.editClient.path;
+
+  final isAuthenticated = _authNotifier.isAuthenticated;
 
   final pathExists = Routes.values.any(
-    (route) =>
-        route.path == state.uri.path ||
-        (state.uri.path.startsWith(route.path) &&
-            route.path != Routes.home.path),
+    (route) => route.path == state.uri.path,
   );
 
   if (!pathExists) {
     return Routes.home.path;
   }
 
-  if (!isLoginRoute && !isSystemRoute) {
-    return null;
+  if (!isAuthenticated && isSystemRoute) {
+    return Routes.login.path;
   }
-
-  final isAuthenticated = _authNotifier.isAuthenticated;
 
   if (isAuthenticated && isLoginRoute) {
     return Routes.systemHome.path;
   }
 
-  if (!isAuthenticated && isSystemRoute) {
-    return Routes.login.path;
+  if (isEditClientRoute) {
+    if (state.extra == null ||
+        state.extra is! Map<String, dynamic> ||
+        !(state.extra! as Map<String, dynamic>).containsKey('client')) {
+      return Routes.systemHome.path;
+    }
   }
 
   return null;

--- a/lib/core/navigation/routes.dart
+++ b/lib/core/navigation/routes.dart
@@ -4,7 +4,9 @@ enum Routes {
   services('/services'),
   connectWithUs('/connect-with-us'),
   login('/login'),
-  systemHome('/system/clients');
+  systemHome('/system/clients'),
+  addClient('/system/clients/add'),
+  editClient('/system/clients/edit');
 
   const Routes(this.path);
 

--- a/lib/system/screens/clients/widgets/client_editor/client_attachments_tab/client_files_header.dart
+++ b/lib/system/screens/clients/widgets/client_editor/client_attachments_tab/client_files_header.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:marketinya/core/design_system/atoms/spaces.dart';
 import 'package:marketinya/core/design_system/molecules/button/primary_button/primary_button.dart';
 import 'package:marketinya/core/design_system/themes/app_colors.dart';
-import 'package:marketinya/core/extensions/context_extension.dart';
 
 class ClientFilesHeader extends StatelessWidget {
   const ClientFilesHeader({super.key});

--- a/lib/system/screens/clients/widgets/client_editor/client_attachments_tab/widgets/file_item.dart
+++ b/lib/system/screens/clients/widgets/client_editor/client_attachments_tab/widgets/file_item.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:marketinya/core/design_system/atoms/icons/file_type_icons.dart';
 import 'package:marketinya/core/design_system/atoms/spaces.dart';
 import 'package:marketinya/core/design_system/molecules/button/primary_button/primary_button.dart';
@@ -94,9 +95,10 @@ class FileItem extends StatelessWidget {
                     icon: const Icon(Icons.check, size: xs),
                     backgroundColor: AppColors.oliveGreen,
                     activeTitleColor: Colors.white,
-                    overlayButtonColor: AppColors.oliveGreen.withValues(alpha: 0.8),
+                    overlayButtonColor:
+                        AppColors.oliveGreen.withValues(alpha: 0.8),
                     onPressed: () {
-                      Navigator.of(context).pop();
+                      context.pop();
                       bloc.add(
                         FileUploadEvent.fileRemoved(
                           fileType: file.fileType,
@@ -115,7 +117,7 @@ class FileItem extends StatelessWidget {
                     activeTitleColor: AppColors.oliveGreen,
                     borderColor: Colors.grey.shade400,
                     overlayButtonColor: AppColors.lightBeige,
-                    onPressed: () => Navigator.of(context).pop(),
+                    onPressed: () => context.pop(),
                   ),
                 ),
               ],

--- a/lib/system/screens/clients/widgets/client_editor/widget/header_section.dart
+++ b/lib/system/screens/clients/widgets/client_editor/widget/header_section.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:marketinya/core/design_system/atoms/spaces.dart';
 import 'package:marketinya/core/design_system/molecules/button/primary_button/primary_button.dart';
@@ -25,7 +26,8 @@ class HeaderSection extends StatelessWidget {
     return BlocListener<AddClientBloc, AddClientState>(
       listener: (context, state) {
         if (state.status == Status.error) {
-          context.showFailureSnackBar(state.errorMessage ?? 'An error occurred');
+          context
+              .showFailureSnackBar(state.errorMessage ?? 'An error occurred');
           return;
         }
         if (state.status == Status.success) {
@@ -34,7 +36,7 @@ class HeaderSection extends StatelessWidget {
               : 'Client created successfully';
 
           context.showSuccessSnackBar(message);
-          Navigator.of(context).pop();
+          context.pop();
         }
       },
       child: Column(

--- a/lib/system/screens/clients/widgets/clients_table/clients_list.dart
+++ b/lib/system/screens/clients/widgets/clients_table/clients_list.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:marketinya/core/extensions/context_extension.dart';
+import 'package:go_router/go_router.dart';
 import 'package:marketinya/core/models/client.dart';
+import 'package:marketinya/core/navigation/routes.dart';
 import 'package:marketinya/system/screens/clients/bloc/client_bloc.dart';
-import 'package:marketinya/system/screens/clients/widgets/client_editor/client_editor_screen.dart';
 import 'package:marketinya/system/screens/clients/widgets/clients_table/clients_table_row.dart';
 
 class ClientsList extends StatelessWidget {
@@ -31,14 +31,19 @@ class ClientsList extends StatelessWidget {
         return ClientsTableRow(
           client: client,
           rowNumber: rowNumber,
-          onTap: () => context.push(
-            ClientEditorScreen(
-              client: client,
-              onClientUpdated: (client) => context.read<ClientBloc>().add(
-                ClientEvent.onClientUpdated(client),
-              ),
-            ),
-          ),
+          onTap: () {
+            context.push(
+              Routes.editClient.path,
+              extra: {
+                'client': client,
+                'onClientUpdated': (Client updatedClient) {
+                  context.read<ClientBloc>().add(
+                        ClientEvent.onClientUpdated(updatedClient),
+                      );
+                },
+              },
+            );
+          },
         );
       },
     );

--- a/lib/system/screens/clients/widgets/content_header.dart
+++ b/lib/system/screens/clients/widgets/content_header.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:marketinya/core/design_system/atoms/dimensions.dart';
 import 'package:marketinya/core/design_system/atoms/spaces.dart';
 import 'package:marketinya/core/design_system/molecules/button/primary_button/primary_button.dart';
 import 'package:marketinya/core/design_system/molecules/fields.dart';
 import 'package:marketinya/core/design_system/themes/app_colors.dart';
-import 'package:marketinya/core/extensions/context_extension.dart';
+import 'package:marketinya/core/models/client.dart';
+import 'package:marketinya/core/navigation/routes.dart';
 import 'package:marketinya/system/screens/clients/bloc/client_bloc.dart';
-import 'package:marketinya/system/screens/clients/widgets/client_editor/client_editor_screen.dart';
 
 class ContentHeader extends StatelessWidget {
   const ContentHeader({super.key});
@@ -80,14 +81,18 @@ class ContentHeader extends StatelessWidget {
                   child: PrimaryButton.responsive(
                     icon: const Icon(Icons.add),
                     title: 'Добави Клиент',
-                    onPressed: () => context.push(
-                      ClientEditorScreen(
-                        onClientUpdated: (client) =>
+                    onPressed: () {
+                      context.push(
+                        Routes.addClient.path,
+                        extra: {
+                          'onClientUpdated': (Client client) {
                             context.read<ClientBloc>().add(
                                   ClientEvent.onClientUpdated(client),
-                                ),
-                      ),
-                    ),
+                                );
+                          },
+                        },
+                      );
+                    },
                     backgroundColor: AppColors.oliveGreen,
                     activeTitleColor: Colors.white,
                   ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.9
+version: 1.1.10
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
This PR refactors the existing routing implementation for the system section of the app to use go_router, a declarative and robust routing package for Flutter.

Closes #19
