### PR TITLE
Feature: Update deploy-to-wip job to use environment variable

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -26,7 +26,7 @@ jobs:
         run: flutter analyze --fatal-infos
 
       - name: 🏗️ Build Flutter Web
-        run: flutter build web --release --dart-define=environment=wip
+        run: flutter build web --release --dart-define=environment=wip --dart-define=VAULT_API_KEY=${{ secrets.VAULT_API_KEY }}
 
       - name: 🚀 Deploy to WIP Environment
         uses: FirebaseExtended/action-hosting-deploy@v0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.11
+version: 1.1.12
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
This PR adds **VAULT_API_KEY** environment variable to deploy-to-wip job and GitHub Actions

Closes #32
