### PR TITLE
Feature: Implement client deletion with Firestore and Storage cleanup

### DIFF
--- a/DB_SCHEMA.md
+++ b/DB_SCHEMA.md
@@ -1,0 +1,105 @@
+# Database Structure
+
+## Firestore Collections
+
+### `clients` Collection
+```
+clients/
+├── {clientId}/
+│   ├── companyName: String
+│   ├── name: String
+│   ├── dateOfBirth: Timestamp
+│   ├── businessSector: String
+│   ├── companyId: String
+│   ├── personalId: String
+│   ├── phone: String
+│   ├── status: String
+│   ├── priorityLevel: String
+│   ├── description: String
+│   ├── assignedTo: DocumentReference
+│   ├── tags: List<DocumentReference>
+│   ├── socialLinks: List<Map>
+│   ├── createdAt: Timestamp
+│   ├── updatedAt: Timestamp
+│   │
+│   └── attachments/
+│       └── {fileId}/
+│           ├── id: String
+│           ├── name: String
+│           ├── fileType: String
+│           ├── size: int
+│           ├── mimeType: String
+│           ├── storagePath: String
+│           ├── downloadUrl: String
+│           ├── lastModified: Timestamp
+│           └── uploadedAt: Timestamp
+```
+
+### `users` Collection
+```
+users/
+├── {userId}/
+│   ├── email: String
+│   ├── displayName: String
+│   ├── role: String
+│   ├── createdAt: Timestamp
+│   └── lastLogin: Timestamp
+```
+
+### `tags` Collection
+```
+tags/
+├── {tagId}/
+│   ├── name: String
+│   ├── color: String
+│   └── createdAt: Timestamp
+```
+
+### `questions` Collection
+```
+questions/
+├── {questionId}/
+│   ├── name: String
+│   ├── email: String
+│   ├── phone: String
+│   ├── message: String
+│   ├── createdAt: Timestamp
+│   └── status: String
+```
+
+### `subscriptions` Collection
+```
+subscriptions/
+├── {subscriptionId}/
+│   ├── email: String
+│   ├── name: String
+│   ├── createdAt: Timestamp
+│   └── status: String
+```
+
+## Firebase Storage Structure
+
+```
+attachments/
+├── {clientId}/
+│   ├── pdf/
+│   │   ├── {fileId1}.pdf
+│   │   └── {fileId2}.pdf
+│   │
+│   ├── image/
+│   │   ├── {fileId3}.jpg
+│   │   ├── {fileId4}.png
+│   │   └── {fileId5}.webp
+│   │
+│   └── txt/
+│       ├── {fileId6}.txt
+│       ├── {fileId7}.docx
+│       └── {fileId8}.xlsx
+```
+
+## Relationships
+
+- **Client-User**: Each client is assigned to a user (`assignedTo` field)
+- **Client-Tags**: Clients can have multiple tags (`tags` field)
+- **Client-Attachments**: One-to-many relationship via subcollection
+- **Attachments-Storage**: Each attachment document references a file in Firebase Storage

--- a/lib/core/config/service_locator.dart
+++ b/lib/core/config/service_locator.dart
@@ -34,7 +34,7 @@ Future<void> initializeDependencyInjection() async {
   getIt.registerLazySingleton<AuthenticationRepository>(() => AuthenticationRepository());
   getIt.registerLazySingleton<UserRepository>(() => UserRepository(getIt<FirestoreService>(), getIt<SharedPreferences>()));
   getIt.registerLazySingleton<ContactRepository>(() => ContactRepository(getIt<FirestoreService>()));
-  getIt.registerLazySingleton<ClientRepository>(() => ClientRepository(getIt<FirestoreService>()));
+  getIt.registerLazySingleton<ClientRepository>(() => ClientRepository(getIt<FirestoreService>(), getIt<FirebaseStorageService>()));
   getIt.registerLazySingleton<AttachmentRepository>(
     () => AttachmentRepository(
       getIt<FirebaseStorageService>(),

--- a/lib/core/design_system/molecules/dialogs.dart
+++ b/lib/core/design_system/molecules/dialogs.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:marketinya/core/design_system/atoms/spaces.dart';
+import 'package:marketinya/core/design_system/molecules/button/primary_button/primary_button.dart';
+import 'package:marketinya/core/design_system/themes/app_colors.dart';
 
 class CustomAlertDialog extends StatelessWidget {
   const CustomAlertDialog({
@@ -10,6 +12,19 @@ class CustomAlertDialog extends StatelessWidget {
     this.scrollable = false,
     this.contentMaxWidth = imageWidth,
   });
+
+  factory CustomAlertDialog.deleteConfirmation({
+    Key? key,
+    Widget? content,
+    required VoidCallback onConfirm,
+    required VoidCallback onCancel,
+  }) =>
+      _DeleteConfirmationDialog(
+        key: key,
+        content: content,
+        onConfirm: onConfirm,
+        onCancel: onCancel,
+      );
 
   final bool scrollable;
   final Widget title;
@@ -29,4 +44,55 @@ class CustomAlertDialog extends StatelessWidget {
       actions: actions,
     );
   }
+}
+
+class _DeleteConfirmationDialog extends CustomAlertDialog {
+  _DeleteConfirmationDialog({
+    super.key,
+    Widget? content,
+    required VoidCallback onConfirm,
+    required VoidCallback onCancel,
+  }) : super(
+          title: const Text(
+            'Сигурни ли сте, че искате да изтриете?',
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+              color: Colors.black,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          content: content ?? const SizedBox.shrink(),
+          actions: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                SizedBox(
+                  width: 120,
+                  child: PrimaryButton.responsive(
+                    title: 'Да',
+                    icon: const Icon(Icons.check, size: xs),
+                    activeTitleColor: Colors.red,
+                    borderColor: Colors.red,
+                    backgroundColor: Colors.white,
+                    overlayButtonColor: Colors.red.withValues(alpha: 200),
+                    onPressed: onConfirm,
+                  ),
+                ),
+                SizedBox(
+                  width: 120,
+                  child: PrimaryButton.responsive(
+                    title: 'Не',
+                    icon: const Icon(Icons.close, size: xs),
+                    backgroundColor: Colors.white,
+                    activeTitleColor: AppColors.oliveGreen,
+                    borderColor: Colors.grey.shade400,
+                    overlayButtonColor: AppColors.lightBeige,
+                    onPressed: onCancel,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        );
 }

--- a/lib/core/design_system/molecules/dialogs.dart
+++ b/lib/core/design_system/molecules/dialogs.dart
@@ -13,17 +13,19 @@ class CustomAlertDialog extends StatelessWidget {
     this.contentMaxWidth = imageWidth,
   });
 
-  factory CustomAlertDialog.deleteConfirmation({
+  static Widget deleteConfirmation({
     Key? key,
     Widget? content,
-    required VoidCallback onConfirm,
-    required VoidCallback onCancel,
+    required VoidCallback? onConfirm,
+    required VoidCallback? onCancel,
+    bool isLoading = false,
   }) =>
       _DeleteConfirmationDialog(
         key: key,
         content: content,
         onConfirm: onConfirm,
         onCancel: onCancel,
+        isLoading: isLoading,
       );
 
   final bool scrollable;
@@ -46,53 +48,65 @@ class CustomAlertDialog extends StatelessWidget {
   }
 }
 
-class _DeleteConfirmationDialog extends CustomAlertDialog {
-  _DeleteConfirmationDialog({
+class _DeleteConfirmationDialog extends StatelessWidget {
+  const _DeleteConfirmationDialog({
     super.key,
-    Widget? content,
-    required VoidCallback onConfirm,
-    required VoidCallback onCancel,
-  }) : super(
-          title: const Text(
-            'Сигурни ли сте, че искате да изтриете?',
-            style: TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.w600,
-              color: Colors.black,
+    this.content,
+    required this.onConfirm,
+    required this.onCancel,
+    this.isLoading = false,
+  });
+
+  final Widget? content;
+  final VoidCallback? onConfirm;
+  final VoidCallback? onCancel;
+  final bool isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomAlertDialog(
+      title: const Text(
+        'Сигурни ли сте, че искате да изтриете?',
+        style: TextStyle(
+          fontSize: 18,
+          fontWeight: FontWeight.w600,
+          color: Colors.black,
+        ),
+        textAlign: TextAlign.center,
+      ),
+      content: content ?? const SizedBox.shrink(),
+      actions: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            SizedBox(
+              width: 120,
+              child: PrimaryButton.responsive(
+                title: 'Да',
+                icon: const Icon(Icons.check, size: xs),
+                activeTitleColor: Colors.red,
+                borderColor: isLoading ? null : Colors.red,
+                backgroundColor: Colors.white,
+                overlayButtonColor: Colors.red.withValues(alpha: 200),
+                onPressed: onConfirm,
+                isLoading: isLoading,
+              ),
             ),
-            textAlign: TextAlign.center,
-          ),
-          content: content ?? const SizedBox.shrink(),
-          actions: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                SizedBox(
-                  width: 120,
-                  child: PrimaryButton.responsive(
-                    title: 'Да',
-                    icon: const Icon(Icons.check, size: xs),
-                    activeTitleColor: Colors.red,
-                    borderColor: Colors.red,
-                    backgroundColor: Colors.white,
-                    overlayButtonColor: Colors.red.withValues(alpha: 200),
-                    onPressed: onConfirm,
-                  ),
-                ),
-                SizedBox(
-                  width: 120,
-                  child: PrimaryButton.responsive(
-                    title: 'Не',
-                    icon: const Icon(Icons.close, size: xs),
-                    backgroundColor: Colors.white,
-                    activeTitleColor: AppColors.oliveGreen,
-                    borderColor: Colors.grey.shade400,
-                    overlayButtonColor: AppColors.lightBeige,
-                    onPressed: onCancel,
-                  ),
-                ),
-              ],
+            SizedBox(
+              width: 120,
+              child: PrimaryButton.responsive(
+                title: 'Не',
+                icon: const Icon(Icons.close, size: xs),
+                backgroundColor: Colors.white,
+                activeTitleColor: AppColors.oliveGreen,
+                borderColor: Colors.grey.shade400,
+                overlayButtonColor: AppColors.lightBeige,
+                onPressed: onCancel,
+              ),
             ),
           ],
-        );
+        ),
+      ],
+    );
+  }
 }

--- a/lib/core/models/client.dart
+++ b/lib/core/models/client.dart
@@ -30,6 +30,7 @@ class Client with _$Client {
     @Default('') String assignedToId,
     @Default([]) List<String> tagIds,
     @Default([]) List<SocialMediaLink> socialLinks,
+    @Default(false) bool isDeleted,
   }) = _Client;
 
   factory Client.fromJson(Map<String, dynamic> json) => _$ClientFromJson(json);

--- a/lib/core/models/client.freezed.dart
+++ b/lib/core/models/client.freezed.dart
@@ -42,6 +42,7 @@ mixin _$Client {
   String get assignedToId => throw _privateConstructorUsedError;
   List<String> get tagIds => throw _privateConstructorUsedError;
   List<SocialMediaLink> get socialLinks => throw _privateConstructorUsedError;
+  bool get isDeleted => throw _privateConstructorUsedError;
 
   /// Serializes this Client to a JSON map.
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -75,7 +76,8 @@ abstract class $ClientCopyWith<$Res> {
       @DocumentReferenceConverter() List<DocumentReference<Object?>> tags,
       String assignedToId,
       List<String> tagIds,
-      List<SocialMediaLink> socialLinks});
+      List<SocialMediaLink> socialLinks,
+      bool isDeleted});
 }
 
 /// @nodoc
@@ -111,6 +113,7 @@ class _$ClientCopyWithImpl<$Res, $Val extends Client>
     Object? assignedToId = null,
     Object? tagIds = null,
     Object? socialLinks = null,
+    Object? isDeleted = null,
   }) {
     return _then(_value.copyWith(
       id: null == id
@@ -185,6 +188,10 @@ class _$ClientCopyWithImpl<$Res, $Val extends Client>
           ? _value.socialLinks
           : socialLinks // ignore: cast_nullable_to_non_nullable
               as List<SocialMediaLink>,
+      isDeleted: null == isDeleted
+          ? _value.isDeleted
+          : isDeleted // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 }
@@ -214,7 +221,8 @@ abstract class _$$ClientImplCopyWith<$Res> implements $ClientCopyWith<$Res> {
       @DocumentReferenceConverter() List<DocumentReference<Object?>> tags,
       String assignedToId,
       List<String> tagIds,
-      List<SocialMediaLink> socialLinks});
+      List<SocialMediaLink> socialLinks,
+      bool isDeleted});
 }
 
 /// @nodoc
@@ -248,6 +256,7 @@ class __$$ClientImplCopyWithImpl<$Res>
     Object? assignedToId = null,
     Object? tagIds = null,
     Object? socialLinks = null,
+    Object? isDeleted = null,
   }) {
     return _then(_$ClientImpl(
       id: null == id
@@ -322,6 +331,10 @@ class __$$ClientImplCopyWithImpl<$Res>
           ? _value._socialLinks
           : socialLinks // ignore: cast_nullable_to_non_nullable
               as List<SocialMediaLink>,
+      isDeleted: null == isDeleted
+          ? _value.isDeleted
+          : isDeleted // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -348,7 +361,8 @@ class _$ClientImpl implements _Client {
       required final List<DocumentReference<Object?>> tags,
       this.assignedToId = '',
       final List<String> tagIds = const [],
-      final List<SocialMediaLink> socialLinks = const []})
+      final List<SocialMediaLink> socialLinks = const [],
+      this.isDeleted = false})
       : _tags = tags,
         _tagIds = tagIds,
         _socialLinks = socialLinks;
@@ -416,8 +430,12 @@ class _$ClientImpl implements _Client {
   }
 
   @override
+  @JsonKey()
+  final bool isDeleted;
+
+  @override
   String toString() {
-    return 'Client(id: $id, companyName: $companyName, name: $name, dateOfBirth: $dateOfBirth, businessSector: $businessSector, companyId: $companyId, personalId: $personalId, phone: $phone, status: $status, priorityLevel: $priorityLevel, description: $description, createdAt: $createdAt, updatedAt: $updatedAt, assignedTo: $assignedTo, tags: $tags, assignedToId: $assignedToId, tagIds: $tagIds, socialLinks: $socialLinks)';
+    return 'Client(id: $id, companyName: $companyName, name: $name, dateOfBirth: $dateOfBirth, businessSector: $businessSector, companyId: $companyId, personalId: $personalId, phone: $phone, status: $status, priorityLevel: $priorityLevel, description: $description, createdAt: $createdAt, updatedAt: $updatedAt, assignedTo: $assignedTo, tags: $tags, assignedToId: $assignedToId, tagIds: $tagIds, socialLinks: $socialLinks, isDeleted: $isDeleted)';
   }
 
   @override
@@ -454,31 +472,35 @@ class _$ClientImpl implements _Client {
                 other.assignedToId == assignedToId) &&
             const DeepCollectionEquality().equals(other._tagIds, _tagIds) &&
             const DeepCollectionEquality()
-                .equals(other._socialLinks, _socialLinks));
+                .equals(other._socialLinks, _socialLinks) &&
+            (identical(other.isDeleted, isDeleted) ||
+                other.isDeleted == isDeleted));
   }
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      id,
-      companyName,
-      name,
-      dateOfBirth,
-      businessSector,
-      companyId,
-      personalId,
-      phone,
-      status,
-      priorityLevel,
-      description,
-      createdAt,
-      updatedAt,
-      assignedTo,
-      const DeepCollectionEquality().hash(_tags),
-      assignedToId,
-      const DeepCollectionEquality().hash(_tagIds),
-      const DeepCollectionEquality().hash(_socialLinks));
+  int get hashCode => Object.hashAll([
+        runtimeType,
+        id,
+        companyName,
+        name,
+        dateOfBirth,
+        businessSector,
+        companyId,
+        personalId,
+        phone,
+        status,
+        priorityLevel,
+        description,
+        createdAt,
+        updatedAt,
+        assignedTo,
+        const DeepCollectionEquality().hash(_tags),
+        assignedToId,
+        const DeepCollectionEquality().hash(_tagIds),
+        const DeepCollectionEquality().hash(_socialLinks),
+        isDeleted
+      ]);
 
   /// Create a copy of Client
   /// with the given fields replaced by the non-null parameter values.
@@ -517,7 +539,8 @@ abstract class _Client implements Client {
       required final List<DocumentReference<Object?>> tags,
       final String assignedToId,
       final List<String> tagIds,
-      final List<SocialMediaLink> socialLinks}) = _$ClientImpl;
+      final List<SocialMediaLink> socialLinks,
+      final bool isDeleted}) = _$ClientImpl;
 
   factory _Client.fromJson(Map<String, dynamic> json) = _$ClientImpl.fromJson;
 
@@ -559,6 +582,8 @@ abstract class _Client implements Client {
   List<String> get tagIds;
   @override
   List<SocialMediaLink> get socialLinks;
+  @override
+  bool get isDeleted;
 
   /// Create a copy of Client
   /// with the given fields replaced by the non-null parameter values.

--- a/lib/core/models/client.g.dart
+++ b/lib/core/models/client.g.dart
@@ -35,6 +35,7 @@ _$ClientImpl _$$ClientImplFromJson(Map<String, dynamic> json) => _$ClientImpl(
               ?.map((e) => SocialMediaLink.fromJson(e as Map<String, dynamic>))
               .toList() ??
           const [],
+      isDeleted: json['isDeleted'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$$ClientImplToJson(_$ClientImpl instance) =>
@@ -59,6 +60,7 @@ Map<String, dynamic> _$$ClientImplToJson(_$ClientImpl instance) =>
       'assignedToId': instance.assignedToId,
       'tagIds': instance.tagIds,
       'socialLinks': instance.socialLinks,
+      'isDeleted': instance.isDeleted,
     };
 
 const _$BusinessSectorEnumMap = {

--- a/lib/core/services/firebase_storage_service.dart
+++ b/lib/core/services/firebase_storage_service.dart
@@ -47,4 +47,23 @@ class FirebaseStorageService {
   }) {
     return '$_baseAttachmentsPath/$clientId/$fileType/$fileId.$extension';
   }
+
+  /// Delete a folder and all its contents from Firebase Storage
+  Future<void> deleteFolder(String folderPath) async {
+    try {
+      final ref = _storage.ref().child(folderPath);
+      final result = await ref.listAll();
+
+      for (final item in result.items) {
+        await item.delete();
+      }
+
+      for (final prefix in result.prefixes) {
+        await deleteFolder('$folderPath/${prefix.name}');
+      }
+    } catch (e) {
+      Log.error('Failed to delete folder: $e');
+      throw Exception('Failed to delete folder: $e');
+    }
+  }
 }

--- a/lib/core/services/firebase_storage_service.dart
+++ b/lib/core/services/firebase_storage_service.dart
@@ -49,7 +49,16 @@ class FirebaseStorageService {
   }
 
   /// Delete a folder and all its contents from Firebase Storage
-  Future<void> deleteFolder(String folderPath) async {
+  Future<void> deleteFolder(String folderPath, [int currentDepth = 0]) async {
+    const maxAllowedDepth = 5;
+
+    if (currentDepth > maxAllowedDepth) {
+      Log.warning(
+        'Folder deletion stopped at maximum depth ($maxAllowedDepth) for path: $folderPath',
+      );
+      return;
+    }
+
     try {
       final ref = _storage.ref().child(folderPath);
       final result = await ref.listAll();
@@ -59,11 +68,10 @@ class FirebaseStorageService {
       }
 
       for (final prefix in result.prefixes) {
-        await deleteFolder('$folderPath/${prefix.name}');
+        await deleteFolder('$folderPath/${prefix.name}', currentDepth + 1);
       }
     } catch (e) {
       Log.error('Failed to delete folder: $e');
-      throw Exception('Failed to delete folder: $e');
     }
   }
 }

--- a/lib/core/services/firestore_service.dart
+++ b/lib/core/services/firestore_service.dart
@@ -44,4 +44,34 @@ class FirestoreService {
   CollectionReference<Map<String, dynamic>> getCollection(String collection) {
     return _firestore.collection(collection);
   }
+
+  Future<void> deleteCollection(String collection, String docId) async {
+    try {
+      await _firestore.collection(collection).doc(docId).delete();
+    } catch (e) {
+      throw Exception('Failed to delete document: $e');
+    }
+  }
+
+  Future<void> deleteSubcollection(
+    CollectionReference subRef, {
+    int batchSize = 500,
+  }) async {
+    try {
+      while (true) {
+        final snap = await subRef.limit(batchSize).get();
+        if (snap.docs.isEmpty) {
+          break;
+        }
+
+        final batch = FirebaseFirestore.instance.batch();
+        for (final doc in snap.docs) {
+          batch.delete(doc.reference);
+        }
+        await batch.commit();
+      }
+    } catch (e) {
+      throw Exception('Failed to delete subcollection: $e');
+    }
+  }
 }

--- a/lib/system/screens/clients/bloc/client_bloc.dart
+++ b/lib/system/screens/clients/bloc/client_bloc.dart
@@ -61,10 +61,18 @@ class ClientBloc extends Bloc<ClientEvent, ClientState> {
 
     final clientExists = index != -1;
 
-    if (clientExists) {
-      updatedClients[index] = client;
+    // If client is marked as deleted, remove it from the list
+    if (client.isDeleted) {
+      if (clientExists) {
+        updatedClients.removeAt(index);
+      }
     } else {
-      updatedClients.add(client);
+      // Normal update/add logic for non-deleted clients
+      if (clientExists) {
+        updatedClients[index] = client;
+      } else {
+        updatedClients.add(client);
+      }
     }
 
     emit(state.copyWith(clients: updatedClients));

--- a/lib/system/screens/clients/widgets/client_editor/bloc/add_client_bloc.dart
+++ b/lib/system/screens/clients/widgets/client_editor/bloc/add_client_bloc.dart
@@ -33,6 +33,7 @@ class AddClientBloc extends Bloc<AddClientEvent, AddClientState> {
         socialLinksChanged: (e) async => emit(state.copyWith(socialLinks: e.value)),
         save: (_) async => _onSave(emit),
         update: (_) async => _onUpdate(emit),
+        delete: (_) async => _onDelete(emit),
       );
     });
 
@@ -139,6 +140,32 @@ class AddClientBloc extends Bloc<AddClientEvent, AddClientState> {
           errorMessage: 'Failed to update the client. Please try again later.',
         ),
       );
+    }
+  }
+
+  Future<void> _onDelete(Emitter<AddClientState> emit) async {
+    emit(state.copyWith(status: Status.loading));
+
+    if (_client == null) {
+      emit(state.copyWith(
+        status: Status.error,
+        errorMessage: 'Cannot delete: no client data found.',
+      ));
+      Log.error('Delete attempt failed: no existing client data provided.');
+      return;
+    }
+
+    try {
+      await _clientRepository.deleteClient(_client.id);
+      emit(state.copyWith(status: Status.success));
+    } catch (e, stackTrace) {
+      Log.error('Delete failed for client ID: ${_client.id}', error: e);
+      Log.error('Stack trace: $stackTrace');
+
+      emit(state.copyWith(
+        status: Status.error,
+        errorMessage: 'Failed to delete the client. Please try again later.',
+      ));
     }
   }
 

--- a/lib/system/screens/clients/widgets/client_editor/bloc/add_client_bloc.dart
+++ b/lib/system/screens/clients/widgets/client_editor/bloc/add_client_bloc.dart
@@ -147,25 +147,36 @@ class AddClientBloc extends Bloc<AddClientEvent, AddClientState> {
     emit(state.copyWith(status: Status.loading));
 
     if (_client == null) {
-      emit(state.copyWith(
-        status: Status.error,
-        errorMessage: 'Cannot delete: no client data found.',
-      ));
+      emit(
+        state.copyWith(
+          status: Status.error,
+          errorMessage: 'Cannot delete: no client data found.',
+        ),
+      );
       Log.error('Delete attempt failed: no existing client data provided.');
       return;
     }
 
     try {
       await _clientRepository.deleteClient(_client.id);
-      emit(state.copyWith(status: Status.success));
+
+      // Notify the callback that client was deleted
+      _onClientUpdated(_client.copyWith(isDeleted: true));
+
+      emit(state.copyWith(
+        status: Status.success,
+        shouldRedirectToHome: true,
+      ),);
     } catch (e, stackTrace) {
       Log.error('Delete failed for client ID: ${_client.id}', error: e);
       Log.error('Stack trace: $stackTrace');
 
-      emit(state.copyWith(
-        status: Status.error,
-        errorMessage: 'Failed to delete the client. Please try again later.',
-      ));
+      emit(
+        state.copyWith(
+          status: Status.error,
+          errorMessage: 'Failed to delete the client. Please try again later.',
+        ),
+      );
     }
   }
 

--- a/lib/system/screens/clients/widgets/client_editor/bloc/add_client_event.dart
+++ b/lib/system/screens/clients/widgets/client_editor/bloc/add_client_event.dart
@@ -45,5 +45,5 @@ class AddClientEvent with _$AddClientEvent {
 
   const factory AddClientEvent.update() = _UpdateClient;
 
-  const factory AddClientEvent.delete() = _UpdateClient;
+  const factory AddClientEvent.delete() = _DeleteClient;
 }

--- a/lib/system/screens/clients/widgets/client_editor/bloc/add_client_event.dart
+++ b/lib/system/screens/clients/widgets/client_editor/bloc/add_client_event.dart
@@ -44,4 +44,6 @@ class AddClientEvent with _$AddClientEvent {
   const factory AddClientEvent.save() = _SaveClient;
 
   const factory AddClientEvent.update() = _UpdateClient;
+
+  const factory AddClientEvent.delete() = _UpdateClient;
 }

--- a/lib/system/screens/clients/widgets/client_editor/bloc/add_client_event.freezed.dart
+++ b/lib/system/screens/clients/widgets/client_editor/bloc/add_client_event.freezed.dart
@@ -91,7 +91,7 @@ mixin _$AddClientEvent {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -110,7 +110,7 @@ mixin _$AddClientEvent {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -129,7 +129,7 @@ mixin _$AddClientEvent {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -281,7 +281,7 @@ class _$LoadImpl implements _Load {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return load(this);
   }
@@ -303,7 +303,7 @@ class _$LoadImpl implements _Load {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return load?.call(this);
   }
@@ -325,7 +325,7 @@ class _$LoadImpl implements _Load {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (load != null) {
@@ -493,7 +493,7 @@ class _$CompanyNameChangedImpl implements _CompanyNameChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return companyNameChanged(this);
   }
@@ -515,7 +515,7 @@ class _$CompanyNameChangedImpl implements _CompanyNameChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return companyNameChanged?.call(this);
   }
@@ -537,7 +537,7 @@ class _$CompanyNameChangedImpl implements _CompanyNameChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (companyNameChanged != null) {
@@ -713,7 +713,7 @@ class _$NameChangedImpl implements _NameChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return nameChanged(this);
   }
@@ -735,7 +735,7 @@ class _$NameChangedImpl implements _NameChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return nameChanged?.call(this);
   }
@@ -757,7 +757,7 @@ class _$NameChangedImpl implements _NameChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (nameChanged != null) {
@@ -933,7 +933,7 @@ class _$DateOfBirthChangedImpl implements _DateOfBirthChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return dateOfBirthChanged(this);
   }
@@ -955,7 +955,7 @@ class _$DateOfBirthChangedImpl implements _DateOfBirthChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return dateOfBirthChanged?.call(this);
   }
@@ -977,7 +977,7 @@ class _$DateOfBirthChangedImpl implements _DateOfBirthChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (dateOfBirthChanged != null) {
@@ -1155,7 +1155,7 @@ class _$BusinessSectorChangedImpl implements _BusinessSectorChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return businessSectorChanged(this);
   }
@@ -1177,7 +1177,7 @@ class _$BusinessSectorChangedImpl implements _BusinessSectorChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return businessSectorChanged?.call(this);
   }
@@ -1199,7 +1199,7 @@ class _$BusinessSectorChangedImpl implements _BusinessSectorChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (businessSectorChanged != null) {
@@ -1376,7 +1376,7 @@ class _$CompanyIdChangedImpl implements _CompanyIdChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return companyIdChanged(this);
   }
@@ -1398,7 +1398,7 @@ class _$CompanyIdChangedImpl implements _CompanyIdChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return companyIdChanged?.call(this);
   }
@@ -1420,7 +1420,7 @@ class _$CompanyIdChangedImpl implements _CompanyIdChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (companyIdChanged != null) {
@@ -1596,7 +1596,7 @@ class _$PersonalIdChangedImpl implements _PersonalIdChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return personalIdChanged(this);
   }
@@ -1618,7 +1618,7 @@ class _$PersonalIdChangedImpl implements _PersonalIdChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return personalIdChanged?.call(this);
   }
@@ -1640,7 +1640,7 @@ class _$PersonalIdChangedImpl implements _PersonalIdChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (personalIdChanged != null) {
@@ -1816,7 +1816,7 @@ class _$PhoneChangedImpl implements PhoneChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return phoneChanged(this);
   }
@@ -1838,7 +1838,7 @@ class _$PhoneChangedImpl implements PhoneChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return phoneChanged?.call(this);
   }
@@ -1860,7 +1860,7 @@ class _$PhoneChangedImpl implements PhoneChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (phoneChanged != null) {
@@ -2036,7 +2036,7 @@ class _$ClientStatusChangedImpl implements _ClientStatusChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return clientStatusChanged(this);
   }
@@ -2058,7 +2058,7 @@ class _$ClientStatusChangedImpl implements _ClientStatusChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return clientStatusChanged?.call(this);
   }
@@ -2080,7 +2080,7 @@ class _$ClientStatusChangedImpl implements _ClientStatusChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (clientStatusChanged != null) {
@@ -2258,7 +2258,7 @@ class _$PriorityLevelChangedImpl implements _PriorityLevelChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return priorityLevelChanged(this);
   }
@@ -2280,7 +2280,7 @@ class _$PriorityLevelChangedImpl implements _PriorityLevelChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return priorityLevelChanged?.call(this);
   }
@@ -2302,7 +2302,7 @@ class _$PriorityLevelChangedImpl implements _PriorityLevelChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (priorityLevelChanged != null) {
@@ -2479,7 +2479,7 @@ class _$DescriptionChangedImpl implements _DescriptionChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return descriptionChanged(this);
   }
@@ -2501,7 +2501,7 @@ class _$DescriptionChangedImpl implements _DescriptionChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return descriptionChanged?.call(this);
   }
@@ -2523,7 +2523,7 @@ class _$DescriptionChangedImpl implements _DescriptionChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (descriptionChanged != null) {
@@ -2707,7 +2707,7 @@ class _$SocialLinksChangedImpl implements _SocialLinksChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return socialLinksChanged(this);
   }
@@ -2729,7 +2729,7 @@ class _$SocialLinksChangedImpl implements _SocialLinksChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return socialLinksChanged?.call(this);
   }
@@ -2751,7 +2751,7 @@ class _$SocialLinksChangedImpl implements _SocialLinksChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (socialLinksChanged != null) {
@@ -2900,7 +2900,7 @@ class _$SaveClientImpl implements _SaveClient {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return save(this);
   }
@@ -2922,7 +2922,7 @@ class _$SaveClientImpl implements _SaveClient {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return save?.call(this);
   }
@@ -2944,7 +2944,7 @@ class _$SaveClientImpl implements _SaveClient {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (save != null) {
@@ -3084,7 +3084,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return update(this);
   }
@@ -3106,7 +3106,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return update?.call(this);
   }
@@ -3128,7 +3128,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (update != null) {
@@ -3143,18 +3143,18 @@ abstract class _UpdateClient implements AddClientEvent {
 }
 
 /// @nodoc
-abstract class _$$UpdateClientImplCopyWith<$Res> {
-  factory _$$UpdateClientImplCopyWith(
-          _$UpdateClientImpl value, $Res Function(_$UpdateClientImpl) then) =
-      __$$UpdateClientImplCopyWithImpl<$Res>;
+abstract class _$$DeleteClientImplCopyWith<$Res> {
+  factory _$$DeleteClientImplCopyWith(
+          _$DeleteClientImpl value, $Res Function(_$DeleteClientImpl) then) =
+      __$$DeleteClientImplCopyWithImpl<$Res>;
 }
 
 /// @nodoc
-class __$$UpdateClientImplCopyWithImpl<$Res>
-    extends _$AddClientEventCopyWithImpl<$Res, _$UpdateClientImpl>
-    implements _$$UpdateClientImplCopyWith<$Res> {
-  __$$UpdateClientImplCopyWithImpl(
-      _$UpdateClientImpl _value, $Res Function(_$UpdateClientImpl) _then)
+class __$$DeleteClientImplCopyWithImpl<$Res>
+    extends _$AddClientEventCopyWithImpl<$Res, _$DeleteClientImpl>
+    implements _$$DeleteClientImplCopyWith<$Res> {
+  __$$DeleteClientImplCopyWithImpl(
+      _$DeleteClientImpl _value, $Res Function(_$DeleteClientImpl) _then)
       : super(_value, _then);
 
   /// Create a copy of AddClientEvent
@@ -3163,8 +3163,8 @@ class __$$UpdateClientImplCopyWithImpl<$Res>
 
 /// @nodoc
 
-class _$UpdateClientImpl implements _UpdateClient {
-  const _$UpdateClientImpl();
+class _$DeleteClientImpl implements _DeleteClient {
+  const _$DeleteClientImpl();
 
   @override
   String toString() {
@@ -3174,7 +3174,7 @@ class _$UpdateClientImpl implements _UpdateClient {
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
-        (other.runtimeType == runtimeType && other is _$UpdateClientImpl);
+        (other.runtimeType == runtimeType && other is _$DeleteClientImpl);
   }
 
   @override
@@ -3268,7 +3268,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
-    required TResult Function(_UpdateClient value) delete,
+    required TResult Function(_DeleteClient value) delete,
   }) {
     return delete(this);
   }
@@ -3290,7 +3290,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
-    TResult? Function(_UpdateClient value)? delete,
+    TResult? Function(_DeleteClient value)? delete,
   }) {
     return delete?.call(this);
   }
@@ -3312,7 +3312,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
-    TResult Function(_UpdateClient value)? delete,
+    TResult Function(_DeleteClient value)? delete,
     required TResult orElse(),
   }) {
     if (delete != null) {
@@ -3322,6 +3322,6 @@ class _$UpdateClientImpl implements _UpdateClient {
   }
 }
 
-abstract class _UpdateClient implements AddClientEvent {
-  const factory _UpdateClient() = _$UpdateClientImpl;
+abstract class _DeleteClient implements AddClientEvent {
+  const factory _DeleteClient() = _$DeleteClientImpl;
 }

--- a/lib/system/screens/clients/widgets/client_editor/bloc/add_client_event.freezed.dart
+++ b/lib/system/screens/clients/widgets/client_editor/bloc/add_client_event.freezed.dart
@@ -32,6 +32,7 @@ mixin _$AddClientEvent {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -50,6 +51,7 @@ mixin _$AddClientEvent {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -68,6 +70,7 @@ mixin _$AddClientEvent {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -88,6 +91,7 @@ mixin _$AddClientEvent {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -106,6 +110,7 @@ mixin _$AddClientEvent {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -124,6 +129,7 @@ mixin _$AddClientEvent {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -204,6 +210,7 @@ class _$LoadImpl implements _Load {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return load();
   }
@@ -225,6 +232,7 @@ class _$LoadImpl implements _Load {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return load?.call();
   }
@@ -246,6 +254,7 @@ class _$LoadImpl implements _Load {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (load != null) {
@@ -272,6 +281,7 @@ class _$LoadImpl implements _Load {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return load(this);
   }
@@ -293,6 +303,7 @@ class _$LoadImpl implements _Load {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return load?.call(this);
   }
@@ -314,6 +325,7 @@ class _$LoadImpl implements _Load {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (load != null) {
@@ -410,6 +422,7 @@ class _$CompanyNameChangedImpl implements _CompanyNameChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return companyNameChanged(value);
   }
@@ -431,6 +444,7 @@ class _$CompanyNameChangedImpl implements _CompanyNameChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return companyNameChanged?.call(value);
   }
@@ -452,6 +466,7 @@ class _$CompanyNameChangedImpl implements _CompanyNameChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (companyNameChanged != null) {
@@ -478,6 +493,7 @@ class _$CompanyNameChangedImpl implements _CompanyNameChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return companyNameChanged(this);
   }
@@ -499,6 +515,7 @@ class _$CompanyNameChangedImpl implements _CompanyNameChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return companyNameChanged?.call(this);
   }
@@ -520,6 +537,7 @@ class _$CompanyNameChangedImpl implements _CompanyNameChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (companyNameChanged != null) {
@@ -624,6 +642,7 @@ class _$NameChangedImpl implements _NameChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return nameChanged(value);
   }
@@ -645,6 +664,7 @@ class _$NameChangedImpl implements _NameChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return nameChanged?.call(value);
   }
@@ -666,6 +686,7 @@ class _$NameChangedImpl implements _NameChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (nameChanged != null) {
@@ -692,6 +713,7 @@ class _$NameChangedImpl implements _NameChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return nameChanged(this);
   }
@@ -713,6 +735,7 @@ class _$NameChangedImpl implements _NameChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return nameChanged?.call(this);
   }
@@ -734,6 +757,7 @@ class _$NameChangedImpl implements _NameChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (nameChanged != null) {
@@ -838,6 +862,7 @@ class _$DateOfBirthChangedImpl implements _DateOfBirthChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return dateOfBirthChanged(value);
   }
@@ -859,6 +884,7 @@ class _$DateOfBirthChangedImpl implements _DateOfBirthChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return dateOfBirthChanged?.call(value);
   }
@@ -880,6 +906,7 @@ class _$DateOfBirthChangedImpl implements _DateOfBirthChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (dateOfBirthChanged != null) {
@@ -906,6 +933,7 @@ class _$DateOfBirthChangedImpl implements _DateOfBirthChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return dateOfBirthChanged(this);
   }
@@ -927,6 +955,7 @@ class _$DateOfBirthChangedImpl implements _DateOfBirthChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return dateOfBirthChanged?.call(this);
   }
@@ -948,6 +977,7 @@ class _$DateOfBirthChangedImpl implements _DateOfBirthChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (dateOfBirthChanged != null) {
@@ -1054,6 +1084,7 @@ class _$BusinessSectorChangedImpl implements _BusinessSectorChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return businessSectorChanged(value);
   }
@@ -1075,6 +1106,7 @@ class _$BusinessSectorChangedImpl implements _BusinessSectorChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return businessSectorChanged?.call(value);
   }
@@ -1096,6 +1128,7 @@ class _$BusinessSectorChangedImpl implements _BusinessSectorChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (businessSectorChanged != null) {
@@ -1122,6 +1155,7 @@ class _$BusinessSectorChangedImpl implements _BusinessSectorChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return businessSectorChanged(this);
   }
@@ -1143,6 +1177,7 @@ class _$BusinessSectorChangedImpl implements _BusinessSectorChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return businessSectorChanged?.call(this);
   }
@@ -1164,6 +1199,7 @@ class _$BusinessSectorChangedImpl implements _BusinessSectorChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (businessSectorChanged != null) {
@@ -1269,6 +1305,7 @@ class _$CompanyIdChangedImpl implements _CompanyIdChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return companyIdChanged(value);
   }
@@ -1290,6 +1327,7 @@ class _$CompanyIdChangedImpl implements _CompanyIdChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return companyIdChanged?.call(value);
   }
@@ -1311,6 +1349,7 @@ class _$CompanyIdChangedImpl implements _CompanyIdChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (companyIdChanged != null) {
@@ -1337,6 +1376,7 @@ class _$CompanyIdChangedImpl implements _CompanyIdChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return companyIdChanged(this);
   }
@@ -1358,6 +1398,7 @@ class _$CompanyIdChangedImpl implements _CompanyIdChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return companyIdChanged?.call(this);
   }
@@ -1379,6 +1420,7 @@ class _$CompanyIdChangedImpl implements _CompanyIdChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (companyIdChanged != null) {
@@ -1483,6 +1525,7 @@ class _$PersonalIdChangedImpl implements _PersonalIdChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return personalIdChanged(value);
   }
@@ -1504,6 +1547,7 @@ class _$PersonalIdChangedImpl implements _PersonalIdChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return personalIdChanged?.call(value);
   }
@@ -1525,6 +1569,7 @@ class _$PersonalIdChangedImpl implements _PersonalIdChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (personalIdChanged != null) {
@@ -1551,6 +1596,7 @@ class _$PersonalIdChangedImpl implements _PersonalIdChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return personalIdChanged(this);
   }
@@ -1572,6 +1618,7 @@ class _$PersonalIdChangedImpl implements _PersonalIdChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return personalIdChanged?.call(this);
   }
@@ -1593,6 +1640,7 @@ class _$PersonalIdChangedImpl implements _PersonalIdChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (personalIdChanged != null) {
@@ -1697,6 +1745,7 @@ class _$PhoneChangedImpl implements PhoneChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return phoneChanged(value);
   }
@@ -1718,6 +1767,7 @@ class _$PhoneChangedImpl implements PhoneChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return phoneChanged?.call(value);
   }
@@ -1739,6 +1789,7 @@ class _$PhoneChangedImpl implements PhoneChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (phoneChanged != null) {
@@ -1765,6 +1816,7 @@ class _$PhoneChangedImpl implements PhoneChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return phoneChanged(this);
   }
@@ -1786,6 +1838,7 @@ class _$PhoneChangedImpl implements PhoneChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return phoneChanged?.call(this);
   }
@@ -1807,6 +1860,7 @@ class _$PhoneChangedImpl implements PhoneChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (phoneChanged != null) {
@@ -1911,6 +1965,7 @@ class _$ClientStatusChangedImpl implements _ClientStatusChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return clientStatusChanged(value);
   }
@@ -1932,6 +1987,7 @@ class _$ClientStatusChangedImpl implements _ClientStatusChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return clientStatusChanged?.call(value);
   }
@@ -1953,6 +2009,7 @@ class _$ClientStatusChangedImpl implements _ClientStatusChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (clientStatusChanged != null) {
@@ -1979,6 +2036,7 @@ class _$ClientStatusChangedImpl implements _ClientStatusChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return clientStatusChanged(this);
   }
@@ -2000,6 +2058,7 @@ class _$ClientStatusChangedImpl implements _ClientStatusChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return clientStatusChanged?.call(this);
   }
@@ -2021,6 +2080,7 @@ class _$ClientStatusChangedImpl implements _ClientStatusChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (clientStatusChanged != null) {
@@ -2127,6 +2187,7 @@ class _$PriorityLevelChangedImpl implements _PriorityLevelChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return priorityLevelChanged(value);
   }
@@ -2148,6 +2209,7 @@ class _$PriorityLevelChangedImpl implements _PriorityLevelChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return priorityLevelChanged?.call(value);
   }
@@ -2169,6 +2231,7 @@ class _$PriorityLevelChangedImpl implements _PriorityLevelChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (priorityLevelChanged != null) {
@@ -2195,6 +2258,7 @@ class _$PriorityLevelChangedImpl implements _PriorityLevelChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return priorityLevelChanged(this);
   }
@@ -2216,6 +2280,7 @@ class _$PriorityLevelChangedImpl implements _PriorityLevelChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return priorityLevelChanged?.call(this);
   }
@@ -2237,6 +2302,7 @@ class _$PriorityLevelChangedImpl implements _PriorityLevelChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (priorityLevelChanged != null) {
@@ -2342,6 +2408,7 @@ class _$DescriptionChangedImpl implements _DescriptionChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return descriptionChanged(value);
   }
@@ -2363,6 +2430,7 @@ class _$DescriptionChangedImpl implements _DescriptionChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return descriptionChanged?.call(value);
   }
@@ -2384,6 +2452,7 @@ class _$DescriptionChangedImpl implements _DescriptionChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (descriptionChanged != null) {
@@ -2410,6 +2479,7 @@ class _$DescriptionChangedImpl implements _DescriptionChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return descriptionChanged(this);
   }
@@ -2431,6 +2501,7 @@ class _$DescriptionChangedImpl implements _DescriptionChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return descriptionChanged?.call(this);
   }
@@ -2452,6 +2523,7 @@ class _$DescriptionChangedImpl implements _DescriptionChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (descriptionChanged != null) {
@@ -2564,6 +2636,7 @@ class _$SocialLinksChangedImpl implements _SocialLinksChanged {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return socialLinksChanged(value);
   }
@@ -2585,6 +2658,7 @@ class _$SocialLinksChangedImpl implements _SocialLinksChanged {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return socialLinksChanged?.call(value);
   }
@@ -2606,6 +2680,7 @@ class _$SocialLinksChangedImpl implements _SocialLinksChanged {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (socialLinksChanged != null) {
@@ -2632,6 +2707,7 @@ class _$SocialLinksChangedImpl implements _SocialLinksChanged {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return socialLinksChanged(this);
   }
@@ -2653,6 +2729,7 @@ class _$SocialLinksChangedImpl implements _SocialLinksChanged {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return socialLinksChanged?.call(this);
   }
@@ -2674,6 +2751,7 @@ class _$SocialLinksChangedImpl implements _SocialLinksChanged {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (socialLinksChanged != null) {
@@ -2751,6 +2829,7 @@ class _$SaveClientImpl implements _SaveClient {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return save();
   }
@@ -2772,6 +2851,7 @@ class _$SaveClientImpl implements _SaveClient {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return save?.call();
   }
@@ -2793,6 +2873,7 @@ class _$SaveClientImpl implements _SaveClient {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (save != null) {
@@ -2819,6 +2900,7 @@ class _$SaveClientImpl implements _SaveClient {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return save(this);
   }
@@ -2840,6 +2922,7 @@ class _$SaveClientImpl implements _SaveClient {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return save?.call(this);
   }
@@ -2861,6 +2944,7 @@ class _$SaveClientImpl implements _SaveClient {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (save != null) {
@@ -2929,6 +3013,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
     required TResult Function() save,
     required TResult Function() update,
+    required TResult Function() delete,
   }) {
     return update();
   }
@@ -2950,6 +3035,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult? Function()? save,
     TResult? Function()? update,
+    TResult? Function()? delete,
   }) {
     return update?.call();
   }
@@ -2971,6 +3057,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
     TResult Function()? save,
     TResult Function()? update,
+    TResult Function()? delete,
     required TResult orElse(),
   }) {
     if (update != null) {
@@ -2997,6 +3084,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     required TResult Function(_SocialLinksChanged value) socialLinksChanged,
     required TResult Function(_SaveClient value) save,
     required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
   }) {
     return update(this);
   }
@@ -3018,6 +3106,7 @@ class _$UpdateClientImpl implements _UpdateClient {
     TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult? Function(_SaveClient value)? save,
     TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
   }) {
     return update?.call(this);
   }
@@ -3039,10 +3128,195 @@ class _$UpdateClientImpl implements _UpdateClient {
     TResult Function(_SocialLinksChanged value)? socialLinksChanged,
     TResult Function(_SaveClient value)? save,
     TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
     required TResult orElse(),
   }) {
     if (update != null) {
       return update(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _UpdateClient implements AddClientEvent {
+  const factory _UpdateClient() = _$UpdateClientImpl;
+}
+
+/// @nodoc
+abstract class _$$UpdateClientImplCopyWith<$Res> {
+  factory _$$UpdateClientImplCopyWith(
+          _$UpdateClientImpl value, $Res Function(_$UpdateClientImpl) then) =
+      __$$UpdateClientImplCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$$UpdateClientImplCopyWithImpl<$Res>
+    extends _$AddClientEventCopyWithImpl<$Res, _$UpdateClientImpl>
+    implements _$$UpdateClientImplCopyWith<$Res> {
+  __$$UpdateClientImplCopyWithImpl(
+      _$UpdateClientImpl _value, $Res Function(_$UpdateClientImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddClientEvent
+  /// with the given fields replaced by the non-null parameter values.
+}
+
+/// @nodoc
+
+class _$UpdateClientImpl implements _UpdateClient {
+  const _$UpdateClientImpl();
+
+  @override
+  String toString() {
+    return 'AddClientEvent.delete()';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _$UpdateClientImpl);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() load,
+    required TResult Function(String value) companyNameChanged,
+    required TResult Function(String value) nameChanged,
+    required TResult Function(String value) dateOfBirthChanged,
+    required TResult Function(BusinessSector value) businessSectorChanged,
+    required TResult Function(String value) companyIdChanged,
+    required TResult Function(String value) personalIdChanged,
+    required TResult Function(String value) phoneChanged,
+    required TResult Function(ClientStatus value) clientStatusChanged,
+    required TResult Function(PriorityLevel value) priorityLevelChanged,
+    required TResult Function(String value) descriptionChanged,
+    required TResult Function(List<SocialMediaLink> value) socialLinksChanged,
+    required TResult Function() save,
+    required TResult Function() update,
+    required TResult Function() delete,
+  }) {
+    return delete();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function()? load,
+    TResult? Function(String value)? companyNameChanged,
+    TResult? Function(String value)? nameChanged,
+    TResult? Function(String value)? dateOfBirthChanged,
+    TResult? Function(BusinessSector value)? businessSectorChanged,
+    TResult? Function(String value)? companyIdChanged,
+    TResult? Function(String value)? personalIdChanged,
+    TResult? Function(String value)? phoneChanged,
+    TResult? Function(ClientStatus value)? clientStatusChanged,
+    TResult? Function(PriorityLevel value)? priorityLevelChanged,
+    TResult? Function(String value)? descriptionChanged,
+    TResult? Function(List<SocialMediaLink> value)? socialLinksChanged,
+    TResult? Function()? save,
+    TResult? Function()? update,
+    TResult? Function()? delete,
+  }) {
+    return delete?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? load,
+    TResult Function(String value)? companyNameChanged,
+    TResult Function(String value)? nameChanged,
+    TResult Function(String value)? dateOfBirthChanged,
+    TResult Function(BusinessSector value)? businessSectorChanged,
+    TResult Function(String value)? companyIdChanged,
+    TResult Function(String value)? personalIdChanged,
+    TResult Function(String value)? phoneChanged,
+    TResult Function(ClientStatus value)? clientStatusChanged,
+    TResult Function(PriorityLevel value)? priorityLevelChanged,
+    TResult Function(String value)? descriptionChanged,
+    TResult Function(List<SocialMediaLink> value)? socialLinksChanged,
+    TResult Function()? save,
+    TResult Function()? update,
+    TResult Function()? delete,
+    required TResult orElse(),
+  }) {
+    if (delete != null) {
+      return delete();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Load value) load,
+    required TResult Function(_CompanyNameChanged value) companyNameChanged,
+    required TResult Function(_NameChanged value) nameChanged,
+    required TResult Function(_DateOfBirthChanged value) dateOfBirthChanged,
+    required TResult Function(_BusinessSectorChanged value)
+        businessSectorChanged,
+    required TResult Function(_CompanyIdChanged value) companyIdChanged,
+    required TResult Function(_PersonalIdChanged value) personalIdChanged,
+    required TResult Function(PhoneChanged value) phoneChanged,
+    required TResult Function(_ClientStatusChanged value) clientStatusChanged,
+    required TResult Function(_PriorityLevelChanged value) priorityLevelChanged,
+    required TResult Function(_DescriptionChanged value) descriptionChanged,
+    required TResult Function(_SocialLinksChanged value) socialLinksChanged,
+    required TResult Function(_SaveClient value) save,
+    required TResult Function(_UpdateClient value) update,
+    required TResult Function(_UpdateClient value) delete,
+  }) {
+    return delete(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(_Load value)? load,
+    TResult? Function(_CompanyNameChanged value)? companyNameChanged,
+    TResult? Function(_NameChanged value)? nameChanged,
+    TResult? Function(_DateOfBirthChanged value)? dateOfBirthChanged,
+    TResult? Function(_BusinessSectorChanged value)? businessSectorChanged,
+    TResult? Function(_CompanyIdChanged value)? companyIdChanged,
+    TResult? Function(_PersonalIdChanged value)? personalIdChanged,
+    TResult? Function(PhoneChanged value)? phoneChanged,
+    TResult? Function(_ClientStatusChanged value)? clientStatusChanged,
+    TResult? Function(_PriorityLevelChanged value)? priorityLevelChanged,
+    TResult? Function(_DescriptionChanged value)? descriptionChanged,
+    TResult? Function(_SocialLinksChanged value)? socialLinksChanged,
+    TResult? Function(_SaveClient value)? save,
+    TResult? Function(_UpdateClient value)? update,
+    TResult? Function(_UpdateClient value)? delete,
+  }) {
+    return delete?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Load value)? load,
+    TResult Function(_CompanyNameChanged value)? companyNameChanged,
+    TResult Function(_NameChanged value)? nameChanged,
+    TResult Function(_DateOfBirthChanged value)? dateOfBirthChanged,
+    TResult Function(_BusinessSectorChanged value)? businessSectorChanged,
+    TResult Function(_CompanyIdChanged value)? companyIdChanged,
+    TResult Function(_PersonalIdChanged value)? personalIdChanged,
+    TResult Function(PhoneChanged value)? phoneChanged,
+    TResult Function(_ClientStatusChanged value)? clientStatusChanged,
+    TResult Function(_PriorityLevelChanged value)? priorityLevelChanged,
+    TResult Function(_DescriptionChanged value)? descriptionChanged,
+    TResult Function(_SocialLinksChanged value)? socialLinksChanged,
+    TResult Function(_SaveClient value)? save,
+    TResult Function(_UpdateClient value)? update,
+    TResult Function(_UpdateClient value)? delete,
+    required TResult orElse(),
+  }) {
+    if (delete != null) {
+      return delete(this);
     }
     return orElse();
   }

--- a/lib/system/screens/clients/widgets/client_editor/bloc/add_client_state.dart
+++ b/lib/system/screens/clients/widgets/client_editor/bloc/add_client_state.dart
@@ -11,7 +11,8 @@ part 'add_client_state.freezed.dart';
 class AddClientState with _$AddClientState {
   factory AddClientState({
     @Default(Status.initial) Status status,
-    @Default(false) bool isUpdateMode, // True when updating an existing client.
+    @Default(false) bool isUpdateMode,
+    @Default(false) bool shouldRedirectToHome,
     @Default('') String companyName,
     @Default('') String name,
     @Default('') String dateOfBirth,

--- a/lib/system/screens/clients/widgets/client_editor/bloc/add_client_state.freezed.dart
+++ b/lib/system/screens/clients/widgets/client_editor/bloc/add_client_state.freezed.dart
@@ -17,8 +17,8 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$AddClientState {
   Status get status => throw _privateConstructorUsedError;
-  bool get isUpdateMode =>
-      throw _privateConstructorUsedError; // True when updating an existing client.
+  bool get isUpdateMode => throw _privateConstructorUsedError;
+  bool get shouldRedirectToHome => throw _privateConstructorUsedError;
   String get companyName => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
   String get dateOfBirth => throw _privateConstructorUsedError;
@@ -48,6 +48,7 @@ abstract class $AddClientStateCopyWith<$Res> {
   $Res call(
       {Status status,
       bool isUpdateMode,
+      bool shouldRedirectToHome,
       String companyName,
       String name,
       String dateOfBirth,
@@ -79,6 +80,7 @@ class _$AddClientStateCopyWithImpl<$Res, $Val extends AddClientState>
   $Res call({
     Object? status = null,
     Object? isUpdateMode = null,
+    Object? shouldRedirectToHome = null,
     Object? companyName = null,
     Object? name = null,
     Object? dateOfBirth = null,
@@ -100,6 +102,10 @@ class _$AddClientStateCopyWithImpl<$Res, $Val extends AddClientState>
       isUpdateMode: null == isUpdateMode
           ? _value.isUpdateMode
           : isUpdateMode // ignore: cast_nullable_to_non_nullable
+              as bool,
+      shouldRedirectToHome: null == shouldRedirectToHome
+          ? _value.shouldRedirectToHome
+          : shouldRedirectToHome // ignore: cast_nullable_to_non_nullable
               as bool,
       companyName: null == companyName
           ? _value.companyName
@@ -164,6 +170,7 @@ abstract class _$$AddClientStateImplCopyWith<$Res>
   $Res call(
       {Status status,
       bool isUpdateMode,
+      bool shouldRedirectToHome,
       String companyName,
       String name,
       String dateOfBirth,
@@ -193,6 +200,7 @@ class __$$AddClientStateImplCopyWithImpl<$Res>
   $Res call({
     Object? status = null,
     Object? isUpdateMode = null,
+    Object? shouldRedirectToHome = null,
     Object? companyName = null,
     Object? name = null,
     Object? dateOfBirth = null,
@@ -214,6 +222,10 @@ class __$$AddClientStateImplCopyWithImpl<$Res>
       isUpdateMode: null == isUpdateMode
           ? _value.isUpdateMode
           : isUpdateMode // ignore: cast_nullable_to_non_nullable
+              as bool,
+      shouldRedirectToHome: null == shouldRedirectToHome
+          ? _value.shouldRedirectToHome
+          : shouldRedirectToHome // ignore: cast_nullable_to_non_nullable
               as bool,
       companyName: null == companyName
           ? _value.companyName
@@ -273,6 +285,7 @@ class _$AddClientStateImpl implements _AddClientState {
   _$AddClientStateImpl(
       {this.status = Status.initial,
       this.isUpdateMode = false,
+      this.shouldRedirectToHome = false,
       this.companyName = '',
       this.name = '',
       this.dateOfBirth = '',
@@ -293,7 +306,9 @@ class _$AddClientStateImpl implements _AddClientState {
   @override
   @JsonKey()
   final bool isUpdateMode;
-// True when updating an existing client.
+  @override
+  @JsonKey()
+  final bool shouldRedirectToHome;
   @override
   @JsonKey()
   final String companyName;
@@ -338,7 +353,7 @@ class _$AddClientStateImpl implements _AddClientState {
 
   @override
   String toString() {
-    return 'AddClientState(status: $status, isUpdateMode: $isUpdateMode, companyName: $companyName, name: $name, dateOfBirth: $dateOfBirth, businessSector: $businessSector, companyId: $companyId, personalId: $personalId, phone: $phone, clientStatus: $clientStatus, priorityLevel: $priorityLevel, description: $description, socialLinks: $socialLinks, errorMessage: $errorMessage)';
+    return 'AddClientState(status: $status, isUpdateMode: $isUpdateMode, shouldRedirectToHome: $shouldRedirectToHome, companyName: $companyName, name: $name, dateOfBirth: $dateOfBirth, businessSector: $businessSector, companyId: $companyId, personalId: $personalId, phone: $phone, clientStatus: $clientStatus, priorityLevel: $priorityLevel, description: $description, socialLinks: $socialLinks, errorMessage: $errorMessage)';
   }
 
   @override
@@ -349,6 +364,8 @@ class _$AddClientStateImpl implements _AddClientState {
             (identical(other.status, status) || other.status == status) &&
             (identical(other.isUpdateMode, isUpdateMode) ||
                 other.isUpdateMode == isUpdateMode) &&
+            (identical(other.shouldRedirectToHome, shouldRedirectToHome) ||
+                other.shouldRedirectToHome == shouldRedirectToHome) &&
             (identical(other.companyName, companyName) ||
                 other.companyName == companyName) &&
             (identical(other.name, name) || other.name == name) &&
@@ -378,6 +395,7 @@ class _$AddClientStateImpl implements _AddClientState {
       runtimeType,
       status,
       isUpdateMode,
+      shouldRedirectToHome,
       companyName,
       name,
       dateOfBirth,
@@ -405,6 +423,7 @@ abstract class _AddClientState implements AddClientState {
   factory _AddClientState(
       {final Status status,
       final bool isUpdateMode,
+      final bool shouldRedirectToHome,
       final String companyName,
       final String name,
       final String dateOfBirth,
@@ -421,7 +440,9 @@ abstract class _AddClientState implements AddClientState {
   @override
   Status get status;
   @override
-  bool get isUpdateMode; // True when updating an existing client.
+  bool get isUpdateMode;
+  @override
+  bool get shouldRedirectToHome;
   @override
   String get companyName;
   @override

--- a/lib/system/screens/clients/widgets/client_editor/client_attachments_tab/widgets/file_item.dart
+++ b/lib/system/screens/clients/widgets/client_editor/client_attachments_tab/widgets/file_item.dart
@@ -2,9 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:marketinya/core/design_system/atoms/icons/file_type_icons.dart';
 import 'package:marketinya/core/design_system/atoms/spaces.dart';
-import 'package:marketinya/core/design_system/molecules/button/primary_button/primary_button.dart';
 import 'package:marketinya/core/design_system/molecules/dialogs.dart';
-import 'package:marketinya/core/design_system/themes/app_colors.dart';
 import 'package:marketinya/system/screens/clients/widgets/client_editor/client_attachments_tab/bloc/file_upload_bloc.dart';
 import 'package:marketinya/system/screens/clients/widgets/client_editor/client_attachments_tab/bloc/file_upload_event.dart';
 import 'package:marketinya/system/screens/clients/widgets/client_editor/client_attachments_tab/models/uploaded_file.dart';
@@ -61,16 +59,7 @@ class FileItem extends StatelessWidget {
     showDialog(
       context: context,
       builder: (BuildContext context) {
-        return CustomAlertDialog(
-          title: const Text(
-            'Сигурни ли сте, че искате да изтриете?',
-            style: TextStyle(
-              fontSize: 18,
-              fontWeight: FontWeight.w600,
-              color: Colors.black,
-            ),
-            textAlign: TextAlign.center,
-          ),
+        return CustomAlertDialog.deleteConfirmation(
           content: Text(
             file.name,
             textAlign: TextAlign.center,
@@ -83,44 +72,16 @@ class FileItem extends StatelessWidget {
             softWrap: true,
             overflow: TextOverflow.ellipsis,
           ),
-          actions: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                SizedBox(
-                  width: 120,
-                  child: PrimaryButton.responsive(
-                    title: 'Да',
-                    icon: const Icon(Icons.check, size: xs),
-                    backgroundColor: AppColors.oliveGreen,
-                    activeTitleColor: Colors.white,
-                    overlayButtonColor: AppColors.oliveGreen.withValues(alpha: 0.8),
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                      bloc.add(
-                        FileUploadEvent.fileRemoved(
-                          fileType: file.fileType,
-                          fileId: file.id,
-                        ),
-                      );
-                    },
-                  ),
-                ),
-                SizedBox(
-                  width: 120,
-                  child: PrimaryButton.responsive(
-                    title: 'Не',
-                    icon: const Icon(Icons.close, size: xs),
-                    backgroundColor: Colors.white,
-                    activeTitleColor: AppColors.oliveGreen,
-                    borderColor: Colors.grey.shade400,
-                    overlayButtonColor: AppColors.lightBeige,
-                    onPressed: () => Navigator.of(context).pop(),
-                  ),
-                ),
-              ],
-            ),
-          ],
+          onConfirm: () {
+            Navigator.of(context).pop();
+            bloc.add(
+              FileUploadEvent.fileRemoved(
+                fileType: file.fileType,
+                fileId: file.id,
+              ),
+            );
+          },
+          onCancel: () => Navigator.of(context).pop(),
         );
       },
     );

--- a/lib/system/screens/clients/widgets/client_editor/client_editor_screen.dart
+++ b/lib/system/screens/clients/widgets/client_editor/client_editor_screen.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:marketinya/core/config/service_locator.dart';
 import 'package:marketinya/core/design_system/atoms/spaces.dart';
 import 'package:marketinya/core/design_system/themes/app_colors.dart';
+import 'package:marketinya/core/enums/status.dart';
+import 'package:marketinya/core/extensions/context_extension.dart';
 import 'package:marketinya/core/models/client.dart';
+import 'package:marketinya/core/navigation/routes.dart';
 import 'package:marketinya/core/repositories/client_repository.dart';
 import 'package:marketinya/core/repositories/user_repository.dart';
 import 'package:marketinya/system/screens/clients/widgets/client_editor/bloc/add_client_bloc.dart';
+import 'package:marketinya/system/screens/clients/widgets/client_editor/bloc/add_client_state.dart';
 import 'package:marketinya/system/screens/clients/widgets/client_editor/client_attachments_tab/client_files_page.dart';
 import 'package:marketinya/system/screens/clients/widgets/client_editor/enums/client_editor_tab.dart';
 import 'package:marketinya/system/screens/clients/widgets/client_editor/widget/client_form_page.dart';
@@ -73,30 +78,38 @@ class _ClientEditorScreenState extends State<ClientEditorScreen>
         widget.client,
         widget.onClientUpdated,
       ),
-      child: Scaffold(
-        backgroundColor: AppColors.background,
-        body: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            ClientsDrawer(
-              availableTabs: _availableTabs,
-              onItemSelected: _onDrawerItemTap,
-              selectedIndex: _tabController.index,
-            ),
-            Flexible(
-              child: TabBarView(
-                controller: _tabController,
-                physics: const NeverScrollableScrollPhysics(),
-                children: _availableTabs.map((tab) => Padding(
-                  padding: const EdgeInsets.symmetric(vertical: xl, horizontal: 180),
-                  child: switch (tab) {
-                    ClientEditorTab.information => const ClientFormPage(),
-                    ClientEditorTab.attachments => ClientFilesPage(clientId: widget.client!.id)
-                  },
-                ),).toList(),
+      child: BlocListener<AddClientBloc, AddClientState>(
+        listener: (context, state) {
+          if (state.status == Status.success && state.shouldRedirectToHome) {
+            context.showSuccessSnackBar('Client deleted successfully');
+            context.go(Routes.systemHome.path);
+          }
+        },
+        child: Scaffold(
+          backgroundColor: AppColors.background,
+          body: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClientsDrawer(
+                availableTabs: _availableTabs,
+                onItemSelected: _onDrawerItemTap,
+                selectedIndex: _tabController.index,
               ),
-            ),
-          ],
+              Flexible(
+                child: TabBarView(
+                  controller: _tabController,
+                  physics: const NeverScrollableScrollPhysics(),
+                  children: _availableTabs.map((tab) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: xl, horizontal: 180),
+                    child: switch (tab) {
+                      ClientEditorTab.information => const ClientFormPage(),
+                      ClientEditorTab.attachments => ClientFilesPage(clientId: widget.client!.id)
+                    },
+                  ),).toList(),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/system/screens/clients/widgets/client_editor/widget/header_section.dart
+++ b/lib/system/screens/clients/widgets/client_editor/widget/header_section.dart
@@ -120,13 +120,36 @@ class HeaderSection extends StatelessWidget {
     final bloc = context.read<AddClientBloc>();
     showDialog(
       context: context,
-      builder: (BuildContext context) {
-        return CustomAlertDialog.deleteConfirmation(
-          onConfirm: () {
-            Navigator.of(context).pop();
-            bloc.add(const AddClientEvent.delete());
-          },
-          onCancel: () => Navigator.of(context).pop(),
+      barrierDismissible: false, // Prevent closing dialog by clicking outside
+      builder: (BuildContext dialogContext) {
+        return BlocProvider.value(
+          value: bloc, // Provide the existing bloc to the dialog
+          child: BlocConsumer<AddClientBloc, AddClientState>(
+            listener: (context, state) {
+              if (state.status == Status.success &&
+                  state.shouldRedirectToHome) {
+                Navigator.of(dialogContext).pop();
+              }
+              if (state.status == Status.error) {
+                Navigator.of(dialogContext).pop();
+                context.showFailureSnackBar(
+                  state.errorMessage ?? 'Failed to delete client',
+                );
+              }
+            },
+            builder: (context, state) {
+              final isLoading = state.status == Status.loading;
+
+              return CustomAlertDialog.deleteConfirmation(
+                onConfirm: isLoading
+                    ? null
+                    : () => bloc.add(const AddClientEvent.delete()),
+                onCancel:
+                    isLoading ? null : () => Navigator.of(dialogContext).pop(),
+                isLoading: isLoading,
+              );
+            },
+          ),
         );
       },
     );

--- a/lib/system/screens/clients/widgets/client_editor/widget/header_section.dart
+++ b/lib/system/screens/clients/widgets/client_editor/widget/header_section.dart
@@ -117,12 +117,14 @@ class HeaderSection extends StatelessWidget {
   }
 
   void _deleteConfirmationDialog(BuildContext context) {
+    final bloc = context.read<AddClientBloc>();
     showDialog(
       context: context,
       builder: (BuildContext context) {
         return CustomAlertDialog.deleteConfirmation(
           onConfirm: () {
             Navigator.of(context).pop();
+            bloc.add(const AddClientEvent.delete());
           },
           onCancel: () => Navigator.of(context).pop(),
         );

--- a/lib/system/screens/clients/widgets/client_editor/widget/header_section.dart
+++ b/lib/system/screens/clients/widgets/client_editor/widget/header_section.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:marketinya/core/design_system/atoms/spaces.dart';
 import 'package:marketinya/core/design_system/molecules/button/primary_button/primary_button.dart';
+import 'package:marketinya/core/design_system/molecules/dialogs.dart';
 import 'package:marketinya/core/design_system/themes/app_colors.dart';
 import 'package:marketinya/core/enums/status.dart';
 import 'package:marketinya/core/extensions/context_extension.dart';
@@ -77,6 +78,17 @@ class HeaderSection extends StatelessWidget {
                   onPressed: () => context.pop(),
                 ),
               ),
+              const Spacer(),
+              SizedBox(
+                child: PrimaryButton.responsive(
+                  icon: const Icon(Icons.delete),
+                  title: 'Изтрий профил',
+                  activeTitleColor: Colors.red,
+                  borderColor: Colors.red,
+                  overlayButtonColor: Colors.red.withValues(alpha: 200),
+                  onPressed: () => _deleteConfirmationDialog(context),
+                ),
+              ),
             ],
           ),
           const SizedBox(height: lg),
@@ -101,6 +113,20 @@ class HeaderSection extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+
+  void _deleteConfirmationDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return CustomAlertDialog.deleteConfirmation(
+          onConfirm: () {
+            Navigator.of(context).pop();
+          },
+          onCancel: () => Navigator.of(context).pop(),
+        );
+      },
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.12
+version: 1.1.13
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
This PR adds client deletion functionality with a confirmation dialog, including removal of Firestore data, attachments subcollection, and associated Firebase Storage files.

<img width=1726 height=994 alt=image src=https://github.com/user-attachments/assets/6b4bcf8b-157f-444f-be60-8f8c460d8917 />


Closes #22
